### PR TITLE
Prevent Empty Table Throwing Hyva_Admin Validation Exception

### DIFF
--- a/Plugin/HandleEmptyOpCacheFlushLogTable.php
+++ b/Plugin/HandleEmptyOpCacheFlushLogTable.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright © element119. All rights reserved.
+ * See LICENCE.txt for licence details.
+ */
+declare(strict_types=1);
+
+namespace Element119\AdminOpCacheReport\Plugin;
+
+use Hyva\Admin\Model\GridSourceType\ArrayProviderGridSourceType;
+
+class HandleEmptyOpCacheFlushLogTable
+{
+    /**
+     * Workaround to prevent the Hyva_Admin module throwing an exception while attempting to validate grid column keys
+     * when the e119_opcache_admin_flush_history table is empty - which is the case immediately after this module is
+     * first installed. A pull request has been opened upstream to avoid this validation when a table associated with a
+     * Hyva_Admin grid is empty.
+     *
+     * @link https://github.com/hyva-themes/magento2-hyva-admin/pull/89
+     */
+    public function afterGetColumnKeys(ArrayProviderGridSourceType $subject, array $result): array
+    {
+        if (!$result && $subject->getGridName() === 'opcache-flush-log') {
+            return [
+                'log_id',
+                'admin_name',
+                'flushed_at',
+            ];
+        }
+
+        return $result;
+    }
+}

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © element119. All rights reserved.
+ * See LICENCE.txt for licence details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Hyva\Admin\Model\GridSourceType\ArrayProviderGridSourceType">
+        <plugin name="prevent_empty_flush_log_table_causing_hyva_admin_validation_error"
+                type="Element119\AdminOpCacheReport\Plugin\HandleEmptyOpCacheFlushLogTable"/>
+    </type>
+</config>


### PR DESCRIPTION
# Description
This is a workaround to prevent the `Hyva_Admin` module throwing an exception while attempting to validate grid column keys when the `e119_opcache_admin_flush_history` table is empty - which is the case immediately after this module is first installed. A [pull request has been opened upstream](https://github.com/hyva-themes/magento2-hyva-admin/pull/89) to avoid this validation when a table associated with a `Hyva_Admin` grid is empty.

---
Closes #1 
